### PR TITLE
fix: drop `toggle(boolean)` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ function Check() {
 
   return (
     <p>
-      <input type="checkbox" checked={checked} onChange={() => toggle()} />
+      <input type="checkbox" checked={checked} onChange={toggle} />
       <button onClick={check}>Check</button>
       <button onClick={uncheck}>Uncheck</button>
-      <button onClick={() => toggle(true)}>Toggle with argument</button>
     </p>
   );
 }

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import { act, renderHook } from "@testing-library/react-hooks";
 import useToggle from "./index";
 
@@ -70,4 +69,3 @@ test("toggle switch", () => {
 
   expect(result.current[0]).toBe(false);
 });
-/* eslint-enable */

--- a/index.ts
+++ b/index.ts
@@ -4,24 +4,14 @@ export type ToggleOn = () => void;
 
 export type ToggleOff = () => void;
 
-export type Toggle = (nextState?: boolean) => void;
+export type Toggle = () => void;
 
 export default function useToggle(initial = false): [boolean, ToggleOn, ToggleOff, Toggle] {
   const [state, setState] = useState(initial);
 
-  const toggle: Toggle = useCallback(
-    (nextState) => {
-      if (typeof nextState === "boolean") {
-        setState(nextState);
-      } else {
-        setState((s) => !s);
-      }
-    },
-    [setState]
-  );
-
-  const toggleOn = useCallback(() => toggle(true), [toggle]);
-  const toggleOff = useCallback(() => toggle(false), [toggle]);
+  const toggleOn = useCallback(() => setState(true), [setState]);
+  const toggleOff = useCallback(() => setState(false), [setState]);
+  const toggle = useCallback(() => setState((s) => !s), [setState]);
 
   return [state, toggleOn, toggleOff, toggle];
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
-    "lint:types": "tsc --noEmit",
+    "lint:types": "tsc --noEmit --project tsconfig.test.json",
     "lint": "npm-run-all --print-label --parallel lint:* prettier:check",
     "prettier": "prettier --ignore-path .gitignore .",
     "prettier:check": "npm run prettier -- --check",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node"
+  },
   "files": ["./index.test.ts"]
 }


### PR DESCRIPTION
This change allows the following better code:

```diff
-<input type="checkbox" checked={checked} onChange={() => toggle()} />
+<input type="checkbox" checked={checked} onChange={toggle} />
```