### PR TITLE
fix: use relative paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "repository": "ybiquitous/use-toggle",
   "type": "module",
   "exports": {
-    "import": "dist/index.js",
-    "require": "dist/cjs/index.js"
+    "import": "./dist/index.js",
+    "require": "./dist/cjs/index.js"
   },
-  "main": "dist/cjs/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
Following the Node.js official documentation:
https://nodejs.org/api/packages.html#packages_conditional_exports