### PR TITLE
chore: use `publishConfig` in package.json instead of .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-access = public

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "React useToggle() utility hook",
   "author": "Masafumi Koba",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "react",
     "hooks",


### PR DESCRIPTION
See <https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig>