### PR TITLE
fix: add `module` field to `package.json` for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "repository": "ybiquitous/use-toggle",
   "type": "module",
   "exports": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/"


### PR DESCRIPTION
For example, Parcel reads the field for bundling.
See https://parceljs.org/features/dependency-resolution/#package-entries
