### PR TITLE
ci: more readable test job names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: "test for react ${{ matrix.react-version }}"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Just a version number is confusing, e.g. either React or Node.js etc.
